### PR TITLE
Fix pull request actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   buildWindows:


### PR DESCRIPTION
Github has made some security with github action, which disallows the usage of secrets when there are pull requests.
Except this breaks the auto-compilling action.

This is here to fix it.